### PR TITLE
[SASTAA] Fixes for cmd/server/main.go

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -56,8 +56,10 @@ func main() {
 	// Intentionally missing ReadTimeout/ReadHeaderTimeout (slowloris vulnerable server)
 	// A safe server variant will be provided under a different binary.
 	srv := &http.Server{
-		Addr:    ":8080",
-		Handler: mux,
+		Addr:              ":8080",
+		Handler:           mux,
+		ReadTimeout:       1e9, // 1 second
+		ReadHeaderTimeout: 1e9, // 1 second
 	}
 
 	log.Printf("listening on %s", srv.Addr)


### PR DESCRIPTION
## Security Findings Addressed

This pull request addresses the following security findings:

### Finding 1
- **Location**: [Line 58](https://github.com/sreyas-endor/go-sast-vuln/blob/main/cmd/server/main.go#L58)
- **Issue**: A SAST finding was identified in this repository version.
- **CWEs Addressed**:
  - CWE-307: Improper Restriction of Excessive Authentication Attempts
- **Remediation**: Please see SAST result details for more information about how to address the issue.

## Affected Files

- [cmd/server/main.go](https://github.com/sreyas-endor/go-sast-vuln/blob/main/cmd/server/main.go)
